### PR TITLE
Mjml.Net Fix NuGet Package Versioning

### DIFF
--- a/Mjml.Net/Mjml.Net.csproj
+++ b/Mjml.Net/Mjml.Net.csproj
@@ -7,7 +7,6 @@
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
 	  <GenerateDocumentationFile>true</GenerateDocumentationFile>
 	  <NoWarn>1591</NoWarn>
-	  <Version>1.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Closes #103 

The build now uses the version from DirectoryProps opposed to being overridden by the `Mjml.Net.csproj` `1.0.0` version. The log below shows the how the package version has been correctly pulled from DirectoryProps `Mjml.Net.1.0.2.nupkg`.


```log
  Determining projects to restore...
  All projects are up-to-date for restore.
  Mjml.Net.Generator -> /home/runner/work/mjml-net/mjml-net/Mjml.Net.Generator/bin/Release/netstandard2.0/Mjml.Net.Generator.dll
  Mjml.Net -> /home/runner/work/mjml-net/mjml-net/Mjml.Net/bin/Release/net6.0/Mjml.Net.dll
  Successfully created package '/home/runner/work/mjml-net/mjml-net/Mjml.Net.Generator/bin/Release/Mjml.Net.Generator.1.0.2.nupkg'.
  Successfully created package '/home/runner/work/mjml-net/mjml-net/Mjml.Net/bin/Release/Mjml.Net.1.0.2.nupkg'.
  ```