### PR TITLE
Close v:image tag in HeroComponent

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,6 +12,6 @@
     <RepositoryUrl>https://github.com/SebastianStehle/mjml-net.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <Version>1.20.0</Version>
+    <Version>1.21.0</Version>
   </PropertyGroup>
 </Project>

--- a/Mjml.Net/Components/Body/HeroComponent.cs
+++ b/Mjml.Net/Components/Body/HeroComponent.cs
@@ -128,7 +128,7 @@
                     .Style("font-size", "0")
                     .Style("mso-line-height-rule", "exactly"); // Style: outlook-td
 
-                renderer.StartElement("v:image") // Style: outlook-image
+                renderer.StartElement("v:image", true) // Style: outlook-image
                     .Attr("src", BackgroundUrl)
                     .Attr("xmlns:v", "urn:schemas-microsoft-com:vml")
                     .Style("border", "0")


### PR DESCRIPTION
Ensured that the v:image tag rendered within the mj-hero component is correctly closed.

Fixes #161 