### PR TITLE
Fixes hero fixed height mode calculating the height incorrectly

### DIFF
--- a/Mjml.Net/Components/Body/HeroComponent.cs
+++ b/Mjml.Net/Components/Body/HeroComponent.cs
@@ -195,7 +195,7 @@ public partial class HeroComponent : BodyComponentBase
         {
             var height =
                 UnitParser.Parse(Height).Value -
-                UnitParser.Parse(PaddingTop).Value +
+                UnitParser.Parse(PaddingTop).Value -
                 UnitParser.Parse(PaddingBottom).Value;
 
             renderer.StartElement("td") // Style: hero

--- a/Tests/Components/HeroTests.cs
+++ b/Tests/Components/HeroTests.cs
@@ -58,4 +58,19 @@ public class HeroTests
 
         AssertHelpers.HtmlFileAssert("Components.Outputs.HeroDividers.html", result);
     }
+
+    [Fact]
+    public void Should_render_fixed_height_hero_with_height_less_padding()
+    {
+        var source = """
+            <mj-hero mode="fixed-height" height="469px" background-width="600px" background-height="469px"background-color="#2a3448" padding="100px 0px">
+            <mj-divider />
+            <mj-divider />
+                </mj-hero>
+            """;
+
+        var (result, _) = TestHelper.Render(source);
+
+        AssertHelpers.HtmlFileAssert("Components.Outputs.HeroFixedHeight.html", result);
+    }
 }

--- a/Tests/Components/Outputs/HeroFixedHeight.html
+++ b/Tests/Components/Outputs/HeroFixedHeight.html
@@ -1,0 +1,75 @@
+﻿<!--[if mso | IE]>
+<table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" width="600" style="width:600px;">
+  <tr>
+    <td style="line-height:0;font-size:0;mso-line-height-rule:exactly;">
+      <v:image xmlns:v="urn:schemas-microsoft-com:vml" style="border:0;height:469px;mso-position-horizontal:center;position:absolute;top:0;width:600px;z-index:-3;"/>
+      <![endif]-->
+<div style="margin:0 auto;max-width:600px;">
+    <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+        <tbody>
+            <tr style="vertical-align:top;">
+                <td height="269" style="background:#2a3448;background-position:center center;background-repeat:no-repeat;padding:100px 0px;padding-bottom:100px;padding-left:0px;padding-right:0px;padding-top:100px;vertical-align:top;">
+                    <!--[if mso | IE]>
+                    <table border="0" cellpadding="0" cellspacing="0" width="600" style="width:600px;">
+                      <tr>
+                        <td>
+                          <![endif]-->
+                    <div class="mj-hero-content" style="margin:0px auto;">
+                        <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;margin:0px;">
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;margin:0px;">
+                                            <tbody>
+                                                <tr>
+                                                    <td align="center" style="font-size:0px;padding:10px 25px;padding-bottom:10px;padding-left:25px;padding-right:25px;padding-top:10px;word-break:break-word;">
+                                                        <p style="border-top:solid 4px #000000;font-size:1px;margin:0px auto;width:100%;">
+                                                        </p>
+                                                        <!--[if mso | IE]>
+                                                        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" width="350px" style="border-top:solid 4px #000000;font-size:1px;margin:0px auto;width:350px;">
+                                                          <tr>
+                                                            <td style="height:0; line-height:0;">
+                                                              &nbsp;
+                                                            </td>
+                                                          </tr>
+                                                        </table>
+                                                        <![endif]-->
+                                                    </td>
+                                                </tr>
+                                                <tr>
+                                                    <td align="center" style="font-size:0px;padding:10px 25px;padding-bottom:10px;padding-left:25px;padding-right:25px;padding-top:10px;word-break:break-word;">
+                                                        <p style="border-top:solid 4px #000000;font-size:1px;margin:0px auto;width:100%;">
+                                                        </p>
+                                                        <!--[if mso | IE]>
+                                                        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" width="350px" style="border-top:solid 4px #000000;font-size:1px;margin:0px auto;width:350px;">
+                                                          <tr>
+                                                            <td style="height:0; line-height:0;">
+                                                              &nbsp;
+                                                            </td>
+                                                          </tr>
+                                                        </table>
+                                                        <![endif]-->
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <!--[if mso | IE]>
+                        </td>
+                      </tr>
+                    </table>
+                    <![endif]-->
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+<!--[if mso | IE]>
+    </td>
+  </tr>
+</table>
+<![endif]-->

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -27,6 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Remove="Components\Outputs\HeroFixedHeight.html" />
     <None Remove="Components\Outputs\StyleInline3.html" />
   </ItemGroup>
 
@@ -100,6 +101,7 @@
     <EmbeddedResource Include="Components\Outputs\Hero.html" />
     <EmbeddedResource Include="Components\Outputs\HeroDivider.html" />
     <EmbeddedResource Include="Components\Outputs\HeroDividers.html" />
+    <EmbeddedResource Include="Components\Outputs\HeroFixedHeight.html" />
     <EmbeddedResource Include="Components\Outputs\HtmlAttributeInvalid.html" />
     <EmbeddedResource Include="Components\Outputs\HtmlAttributes.html" />
     <EmbeddedResource Include="Components\Outputs\HtmlAttributesNoProcessor.html" />


### PR DESCRIPTION
Fixes an issue with the mj-hero component in fixed-height mode adding on the bottom padding as opposed to taking it away.

See js source code here: https://github.com/mjmlio/mjml/blob/3c8d076030cd0fd6b763ab0d580389432a194433/packages/mjml-hero/src/index.js#L285

![image](https://github.com/user-attachments/assets/7b53757c-5746-4c72-8f83-5c590b977bd3)

vs current .net source code:

![image](https://github.com/user-attachments/assets/b9215665-0fe2-4a2f-b4fc-de43734122fa)
